### PR TITLE
Update binutils-2.23.2 patch for newer Texinfo

### DIFF
--- a/patches/binutils-2.23.2-musl.diff
+++ b/patches/binutils-2.23.2-musl.diff
@@ -17,3 +17,24 @@ diff -r 54fa2047c3af config.sub
  	      | -uxpv* | -beos* | -mpeix* | -udk* \
  	      | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \
  	      | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+diff -Naur a/bfd/doc/bfd.texinfo b/bfd/doc/bfd.texinfo
+--- a/bfd/doc/bfd.texinfo	2010-10-28 07:40:25.000000000 -0400
++++ b/bfd/doc/bfd.texinfo	2013-10-02 15:57:07.556185659 -0400
+@@ -322,7 +322,7 @@
+ @printindex cp
+
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
++% I think something like @@colophon should be in texinfo.  In the
+ % meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+@@ -333,7 +333,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 28mar91.
++% Blame: doc@@cygnus.com, 28mar91.
+ @end tex
+
+ @bye


### PR DESCRIPTION
With some newer versions of Texinfo (>=5), binutils has invalid commands
within its documentation.  Correct this in order to avoid errors like:

config.status: creating po/Makefile
../../../bfd/doc/bfd.texinfo:325: unknown command `colophon'
../../../bfd/doc/bfd.texinfo:336: unknown command`cygnus'
make[3]: **\* [bfd.info] Error 1
