### PR TITLE
defs.sh: Fix buildmake() to use patch_source()

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -245,14 +245,10 @@ buildmake() {
 
     if [ ! -e "$BUILT" ]
     then
+        patch_source "$BD"
+
         (
         cd "$BD" || die "Failed to cd $BD"
-
-        if [ -e "$MUSL_CC_BASE/$BD"-musl.diff -a ! -e patched ]
-        then
-            patch -p1 < "$MUSL_CC_BASE/$BD"-musl.diff || die "Failed to patch $BD"
-            touch patched
-        fi
 
         ( $MAKE "$@" $MAKEFLAGS &&
             touch "$BUILT" ) ||


### PR DESCRIPTION
buildmake() was performing its own patch sequence which would look for
patches in the top level rather than within the patches/ dir.  This was
inconsistent and unneeded.
