### PR TITLE
build-tarballs: Also cleanup `kernel-headers` dir

### DIFF
--- a/extra/build-tarballs.sh
+++ b/extra/build-tarballs.sh
@@ -30,7 +30,7 @@ set -ex
 HG_ID=`cd "$MUSL_CC_BASE" ; hg id | sed 's/ .*//'`
 
 cleanup() {
-    for pkg in binutils gcc linux musl gmp mpfr mpc
+    for pkg in binutils gcc linux kernel-headers musl gmp mpfr mpc
     do
         for bf in configured build built installed
         do


### PR DESCRIPTION
85c89b67314ad29d444d60373c51f0db78d0a247 introduced a potentially
different name for the Linux headers directory name of
"kernel-headers-$VERSION" as that's what Sabotage calls their small
headers only tarball.  If you use vanilla sources (which are much
larger) you'll end up with a Linux headers directory name of
"linux-$VERSION".  To handle these two potentially different directory
names such that the build-tarballs.sh script's cleanup() properly
removes the build indicators, both potential directory names should be
searched in cleanup().

Fixes #30