### PR TITLE
fix stack-protector issue on i486

### DIFF
--- a/patches/gcc-4.8.4-musl.diff
+++ b/patches/gcc-4.8.4-musl.diff
@@ -814,3 +814,14 @@ diff -r be309b9bafc4 gcc/c/c-typeck.c
    /* Handle superfluous braces around string cst as in
       char x[] = {"foo"}; */
    if (string_flag
+--- a/gcc/gcc.c.orig	2013-09-24 06:27:32.133894539 +0000
++++ b/gcc/gcc.c	2013-09-24 06:29:35.790562854 +0000
+@@ -601,7 +601,7 @@
+ 
+ #ifndef LINK_SSP_SPEC
+ #ifdef TARGET_LIBC_PROVIDES_SSP
+-#define LINK_SSP_SPEC "%{fstack-protector:}"
++#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all:-lssp_nonshared}"
+ #else
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all:-lssp_nonshared -lssp}"
+ #endif

--- a/patches/musl-1.1.10-i486-ssp.diff
+++ b/patches/musl-1.1.10-i486-ssp.diff
@@ -1,0 +1,13 @@
+--- a/src/env/__stack_chk_fail.c
++++ b/src/env/__stack_chk_fail.c
+@@ -25,4 +25,8 @@ void __stack_chk_fail_local(void)
+ 	a_crash();
+ }
+ 
++#else
++
++weak_alias(__stack_chk_fail, __stack_chk_fail_local);
++
+ #endif
+
+


### PR DESCRIPTION
  fixes https://github.com/GregorR/musl-cross/issues/45
  the gcc patch is from https://gcc.gnu.org/ml/gcc/2012-01/msg00012.html