### PR TITLE
Update GCC prerequisites

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -34,9 +34,9 @@ BINUTILS_URL=http://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
 #BINUTILS_URL=http://landley.net/aboriginal/mirror/binutils-2.17.tar.bz2
 GCC_VERSION=5.3.0
 GDB_VERSION=7.9.1
-GMP_VERSION=4.3.2
-MPC_VERSION=0.8.1
-MPFR_VERSION=2.4.2
+GMP_VERSION=6.1.0
+MPC_VERSION=1.0.3
+MPFR_VERSION=3.1.4
 LIBELF_VERSION=master
 # use kernel headers from vanilla linux kernel - may be necessary for porting to a bleeding-edge arch
 # LINUX_HEADERS_URL=http://www.kernel.org/pub/linux/kernel/v3.0/linux-3.12.6.tar.xz


### PR DESCRIPTION
Update the GCC prequisites to the latest versions. libgmp was not
available for download anymore.