### PR TITLE
Use HTTPS URLs for downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ buildinstall 1 $BINUTILS_DIR --target=$TRIPLE --disable-werror $SYSROOT_FLAGS \
 # gcc 1
 if [ -z $GCC_URL ];
 then
-    fetchextract http://ftpmirror.gnu.org/gnu/gcc/gcc-$GCC_VERSION/ gcc-$GCC_VERSION .tar.bz2
+    fetchextract $HTTP_PROTO://ftpmirror.gnu.org/gnu/gcc/gcc-$GCC_VERSION/ gcc-$GCC_VERSION .tar.bz2
 else
     fetchextract "$GCC_URL"
     if [ -e $GCC_EXTRACT_DIR ]; then

--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ buildinstall 1 $BINUTILS_DIR --target=$TRIPLE --disable-werror $SYSROOT_FLAGS \
 # gcc 1
 if [ -z $GCC_URL ];
 then
-    fetchextract http://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/ gcc-$GCC_VERSION .tar.bz2
+    fetchextract http://ftpmirror.gnu.org/gnu/gcc/gcc-$GCC_VERSION/ gcc-$GCC_VERSION .tar.bz2
 else
     fetchextract "$GCC_URL"
     if [ -e $GCC_EXTRACT_DIR ]; then

--- a/config.sh
+++ b/config.sh
@@ -24,3 +24,6 @@ MAKEFLAGS=-j8
 
 # Enable this to build the bootstrap gcc (thrown away) without optimization, to reduce build time
 GCC_STAGE1_NOOPT=1
+
+# Uncomment this if your wget does not support HTTPS
+#HTTP_PROTO=http

--- a/defs.sh
+++ b/defs.sh
@@ -28,7 +28,7 @@ then
 fi
 
 # Versions of things (do this before config.sh so they can be config'd)
-BINUTILS_URL=http://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
+BINUTILS_URL=http://ftpmirror.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
 #BINUTILS_URL=http://mirrors.kernel.org/sourceware/binutils/snapshots/binutils-2.24.90.tar.bz2
 #last GPL2 release is 2.17, with backported  -Bsymbolic support
 #BINUTILS_URL=http://landley.net/aboriginal/mirror/binutils-2.17.tar.bz2
@@ -221,19 +221,19 @@ muslfetchextract() {
 gccprereqs() {
     if [ ! -e gcc-$GCC_VERSION/gmp ]
     then
-        fetchextract http://ftp.gnu.org/pub/gnu/gmp/ gmp-$GMP_VERSION .tar.bz2
+        fetchextract http://ftpmirror.gnu.org/pub/gnu/gmp/ gmp-$GMP_VERSION .tar.bz2
         mv gmp-$GMP_VERSION gcc-$GCC_VERSION/gmp
     fi
 
     if [ ! -e gcc-$GCC_VERSION/mpfr ]
     then
-        fetchextract http://ftp.gnu.org/gnu/mpfr/ mpfr-$MPFR_VERSION .tar.bz2
+        fetchextract http://ftpmirror.gnu.org/gnu/mpfr/ mpfr-$MPFR_VERSION .tar.bz2
         mv mpfr-$MPFR_VERSION gcc-$GCC_VERSION/mpfr
     fi
 
     if [ ! -e gcc-$GCC_VERSION/mpc ]
     then
-        fetchextract https://ftp.gnu.org/gnu/mpc/ mpc-$MPC_VERSION .tar.gz
+        fetchextract https://ftpmirror.gnu.org/gnu/mpc/ mpc-$MPC_VERSION .tar.gz
         mv mpc-$MPC_VERSION gcc-$GCC_VERSION/mpc
     fi
 }

--- a/defs.sh
+++ b/defs.sh
@@ -27,11 +27,18 @@ then
     exit 1
 fi
 
-# Versions of things (do this before config.sh so they can be config'd)
-BINUTILS_URL=http://ftpmirror.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
-#BINUTILS_URL=http://mirrors.kernel.org/sourceware/binutils/snapshots/binutils-2.24.90.tar.bz2
+# Default HTTP/HTTPS protocol
+test -z "$HTTP_PROTO" && HTTP_PROTO=https
+
+# We have to load config.sh early in order to get $HTTP_PROTO if it's set there.
+# We do it again down below so that everything else can be overridden.
+. ./config.sh
+
+# Versions of things
+BINUTILS_URL=$HTTP_PROTO://ftpmirror.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
+#BINUTILS_URL=$HTTP_PROTO://mirrors.kernel.org/sourceware/binutils/snapshots/binutils-2.24.90.tar.bz2
 #last GPL2 release is 2.17, with backported  -Bsymbolic support
-#BINUTILS_URL=http://landley.net/aboriginal/mirror/binutils-2.17.tar.bz2
+#BINUTILS_URL=$HTTP_PROTO://landley.net/aboriginal/mirror/binutils-2.17.tar.bz2
 GCC_VERSION=5.3.0
 GDB_VERSION=7.9.1
 GMP_VERSION=6.1.0
@@ -39,10 +46,10 @@ MPC_VERSION=1.0.3
 MPFR_VERSION=3.1.4
 LIBELF_VERSION=master
 # use kernel headers from vanilla linux kernel - may be necessary for porting to a bleeding-edge arch
-# LINUX_HEADERS_URL=http://www.kernel.org/pub/linux/kernel/v3.0/linux-3.12.6.tar.xz
+# LINUX_HEADERS_URL=$HTTP_PROTO://www.kernel.org/pub/linux/kernel/v3.0/linux-3.12.6.tar.xz
 # use patched sabotage-linux kernel-headers package (fixes userspace clashes of some kernel structs)
 # from upstream repo https://github.com/sabotage-linux/kernel-headers
-LINUX_HEADERS_URL=http://ftp.barfooze.de/pub/sabotage/tarballs/kernel-headers-3.12.6-5.tar.xz
+LINUX_HEADERS_URL=$HTTP_PROTO://ftp.barfooze.de/pub/sabotage/tarballs/kernel-headers-3.12.6-5.tar.xz
 
 # musl can optionally be checked out from GIT, in which case MUSL_VERSION must
 # be set to a git tag and MUSL_GIT set to yes in config.sh
@@ -214,20 +221,20 @@ muslfetchextract() {
     then
         gitfetchextract "$MUSL_GIT_REPO" $MUSL_VERSION musl-$MUSL_VERSION
     else
-        fetchextract http://www.musl-libc.org/releases/ musl-$MUSL_VERSION .tar.gz
+        fetchextract $HTTP_PROTO://www.musl-libc.org/releases/ musl-$MUSL_VERSION .tar.gz
     fi
 }
 
 gccprereqs() {
     if [ ! -e gcc-$GCC_VERSION/gmp ]
     then
-        fetchextract http://ftpmirror.gnu.org/pub/gnu/gmp/ gmp-$GMP_VERSION .tar.bz2
+        fetchextract $HTTP_PROTO://ftpmirror.gnu.org/pub/gnu/gmp/ gmp-$GMP_VERSION .tar.bz2
         mv gmp-$GMP_VERSION gcc-$GCC_VERSION/gmp
     fi
 
     if [ ! -e gcc-$GCC_VERSION/mpfr ]
     then
-        fetchextract http://ftpmirror.gnu.org/gnu/mpfr/ mpfr-$MPFR_VERSION .tar.bz2
+        fetchextract $HTTP_PROTO://ftpmirror.gnu.org/gnu/mpfr/ mpfr-$MPFR_VERSION .tar.bz2
         mv mpfr-$MPFR_VERSION gcc-$GCC_VERSION/mpfr
     fi
 


### PR DESCRIPTION
The new GNU URL automatically redirects to a nearby, current GNU mirror.

Also, the HTTPS helps with restrictive outbound firewall policies that disallow plaintext traffic (for example, using Qubes OS' firewall functionality).